### PR TITLE
Add object color attribute

### DIFF
--- a/back/api/handler.go
+++ b/back/api/handler.go
@@ -9,11 +9,12 @@ import (
 )
 
 type WorldResponse struct {
+	CurTime        float32     `json:"CurTime"`
 	IDArray        []string    `json:"IDArray"`
 	PositionArrays [][]float32 `json:"PositionArrays"`
 	VertexArrays   [][]float32 `json:"VertexArrays"`
 	IndexArrays    [][]uint32  `json:"IndexArrays"`
-	CurTime        float32     `json:"CurTime"`
+	ColorArray     []string    `json:"ColorArray"`
 }
 
 func GetWorldObjectsHandler(w http.ResponseWriter, r *http.Request, worlds map[string]*common.World) {
@@ -21,14 +22,15 @@ func GetWorldObjectsHandler(w http.ResponseWriter, r *http.Request, worlds map[s
 
 	world := worlds[id]
 
-	IDArray, PositionArrays, VertexArrays, IndexArrays, CurTime := world.Flatten()
+	CurTime, IDArray, PositionArrays, VertexArrays, IndexArrays, ColorArray := world.Flatten()
 
 	response := WorldResponse{
+		CurTime:        CurTime,
 		IDArray:        IDArray,
 		PositionArrays: PositionArrays,
 		VertexArrays:   VertexArrays,
 		IndexArrays:    IndexArrays,
-		CurTime:        CurTime,
+		ColorArray:     ColorArray,
 	}
 
 	w.Header().Set("Content-Type", "application/json")

--- a/back/common/object.go
+++ b/back/common/object.go
@@ -1,6 +1,5 @@
 package common
 
-
 type Vector3 struct {
 	X float32
 	Y float32
@@ -39,6 +38,8 @@ type Object struct {
 	Mesh     Mesh
 	Position Vector3
 
+	Color string
+
 	Velocity Vector3
 
 	Density  float32
@@ -48,9 +49,9 @@ type Object struct {
 	CenterOfMass Vector3
 }
 
-func (o *Object) Flatten() (string, []float32, []float32, []uint32) {
+func (o *Object) Flatten() (string, []float32, []float32, []uint32, string) {
 	v, i := o.Mesh.Flatten()
-	return o.ID, []float32{o.Position.X, o.Position.Y, o.Position.Z}, v, i
+	return o.ID, []float32{o.Position.X, o.Position.Y, o.Position.Z}, v, i, o.Color
 
 }
 
@@ -59,6 +60,7 @@ func (o Object) DeepCopy() Object {
 	newObj := Object{
 		ID:           o.ID,
 		Position:     Vector3{X: o.Position.X, Y: o.Position.Y, Z: o.Position.Z},
+		Color:        o.Color,
 		Velocity:     Vector3{X: o.Velocity.X, Y: o.Velocity.Y, Z: o.Velocity.Z},
 		Density:      o.Density,
 		Mass:         o.Mass,
@@ -76,7 +78,6 @@ func (o Object) DeepCopy() Object {
 
 	return newObj
 }
-
 
 func (o *Object) UpdatePosition(dt float32) {
 	o.Position.X += o.Velocity.X * dt

--- a/back/common/world.go
+++ b/back/common/world.go
@@ -13,21 +13,23 @@ type World struct {
 	InitialObjects []Object
 }
 
-func (w *World) Flatten() ([]string, [][]float32, [][]float32, [][]uint32, float32) {
+func (w *World) Flatten() (float32, []string, [][]float32, [][]float32, [][]uint32, []string) {
 	IDArray := make([]string, 0, len(w.Objects))
 	PositionArrays := make([][]float32, 0, len(w.Objects))
 	VertexArrays := make([][]float32, 0, len(w.Objects))
 	IndexArrays := make([][]uint32, 0, len(w.Objects))
+	ColorArray := make([]string, 0, len(w.Objects))
 
 	for _, obj := range w.Objects {
-		id, pos, verts, inds := obj.Flatten()
+		id, pos, verts, inds, color := obj.Flatten()
 		IDArray = append(IDArray, id)
 		PositionArrays = append(PositionArrays, pos)
 		VertexArrays = append(VertexArrays, verts)
 		IndexArrays = append(IndexArrays, inds)
+		ColorArray = append(ColorArray, color)
 	}
 
-	return IDArray, PositionArrays, VertexArrays, IndexArrays, w.CurTime
+	return w.CurTime, IDArray, PositionArrays, VertexArrays, IndexArrays, ColorArray
 }
 
 func (w *World) Update() {

--- a/back/example/threeBody.go
+++ b/back/example/threeBody.go
@@ -8,42 +8,43 @@ func ThreeBody() common.World {
 		TimeStep:  0.01,
 		SleepTime: 0.01,
 	}
-/*
-	earthMesh := common.NewSphere(1, 3)
-	earth := common.Object{
-		ID:       "earth",
-		Mesh:     earthMesh,
-		Position: common.Vector3{X: 500, Y: 0, Z: 0},
-		Velocity: common.Vector3{X: 0, Y: 0, Z: 0},
-	}
+	/*
+		earthMesh := common.NewSphere(1, 3)
+		earth := common.Object{
+			ID:       "earth",
+			Mesh:     earthMesh,
+			Position: common.Vector3{X: 500, Y: 0, Z: 0},
+			Velocity: common.Vector3{X: 0, Y: 0, Z: 0},
+		}
 
-	jupiterMesh := common.NewSphere(10, 3)
-	jupiter := common.Object{
-		ID:       "jupiter",
-		Mesh:     jupiterMesh,
-		Position: common.Vector3{X: 200, Y: 0, Z: 0},
-		Velocity: common.Vector3{X: 0, Y: 0, Z: 0},
-	}
+		jupiterMesh := common.NewSphere(10, 3)
+		jupiter := common.Object{
+			ID:       "jupiter",
+			Mesh:     jupiterMesh,
+			Position: common.Vector3{X: 200, Y: 0, Z: 0},
+			Velocity: common.Vector3{X: 0, Y: 0, Z: 0},
+		}
 
-	sunMesh := common.NewSphere(100, 3)
-	sun := common.Object{
-		ID:       "sun",
-		Mesh:     sunMesh,
-		Position: common.Vector3{X: 0, Y: 0, Z: 0},
-		Velocity: common.Vector3{X: 0, Y: 0, Z: 0},
-	}
+		sunMesh := common.NewSphere(100, 3)
+		sun := common.Object{
+			ID:       "sun",
+			Mesh:     sunMesh,
+			Position: common.Vector3{X: 0, Y: 0, Z: 0},
+			Velocity: common.Vector3{X: 0, Y: 0, Z: 0},
+		}
 
-	world.Objects = append(world.Objects, earth)
-	world.Objects = append(world.Objects, sun)
-	world.Objects = append(world.Objects, jupiter)
+		world.Objects = append(world.Objects, earth)
+		world.Objects = append(world.Objects, sun)
+		world.Objects = append(world.Objects, jupiter)
 
-*/
+	*/
 
 	earthMesh := common.NewSphere(6_000_000, 5)
 	earth := common.Object{
 		ID:       "earth",
 		Mesh:     earthMesh,
 		Position: common.Vector3{X: 0, Y: -6_000_000, Z: 0},
+		Color:    "#333333",
 		Velocity: common.Vector3{X: 0, Y: 0, Z: 0},
 	}
 

--- a/front/src/update.js
+++ b/front/src/update.js
@@ -1,4 +1,4 @@
-import * as THREE from 'three';
+import * as THREE from "three";
 
 // Configuration
 export const FRAMERATE = 60; // Fetches per second
@@ -10,21 +10,28 @@ export const objects = new Map();
 // Fetch simulation data from server
 export async function fetchSimulationData(scene) {
   try {
-    const response = await fetch('http://localhost:8080/worlds/threeBody');
+    const response = await fetch("http://localhost:8080/worlds/threeBody");
     const data = await response.json();
     updateSimulation(data, scene);
   } catch (error) {
-    console.error('Error fetching simulation data:', error);
+    console.error("Error fetching simulation data:", error);
   }
 }
 
 // Update simulation objects based on data
 export function updateSimulation(data, scene) {
-  const { IDArray, PositionArrays, VertexArrays, IndexArrays, CurTime } = data;
+  const {
+    CurTime,
+    IDArray,
+    PositionArrays,
+    VertexArrays,
+    IndexArrays,
+    ColorArray,
+  } = data;
 
   // Update the elapsed time display
-  const elapsedTimeDiv = document.getElementById('elapsed-time');
-  if (elapsedTimeDiv && typeof CurTime === 'number') {
+  const elapsedTimeDiv = document.getElementById("elapsed-time");
+  if (elapsedTimeDiv && typeof CurTime === "number") {
     elapsedTimeDiv.textContent = `Time: ${CurTime.toFixed(2)}s`;
   }
 
@@ -32,7 +39,8 @@ export function updateSimulation(data, scene) {
     const objData = {
       positions: PositionArrays[index],
       vertexes: VertexArrays[index],
-      indices: IndexArrays[index]
+      indices: IndexArrays[index],
+      color: ColorArray[index],
     };
 
     if (!objects.has(id)) {
@@ -53,37 +61,42 @@ export function updateSimulation(data, scene) {
 
 // Create a new 3D object
 export function createObject(id, objData, scene) {
-  var { positions, vertexes, indices } = objData;
+  var { positions, vertexes, indices, color } = objData;
   vertexes = new Float32Array(vertexes);
   indices = new Uint32Array(indices);
-  
+
   // Create BufferGeometry
   const geometry = new THREE.BufferGeometry();
-  geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertexes, 3));
+  geometry.setAttribute(
+    "position",
+    new THREE.Float32BufferAttribute(vertexes, 3),
+  );
   geometry.setIndex(new THREE.BufferAttribute(indices, 1));
-  
-  // Create material with random color
-  const material = new THREE.MeshStandardMaterial({ 
-    color: new THREE.Color(Math.random(), Math.random(), Math.random()),
+
+  // Create material using provided color or random fallback
+  const material = new THREE.MeshStandardMaterial({
+    color: color
+      ? new THREE.Color(color)
+      : new THREE.Color(Math.random(), Math.random(), Math.random()),
     roughness: 0.7,
-    metalness: 0.3
+    metalness: 0.3,
   });
-  
+
   // Create mesh
   const threeMesh = new THREE.Mesh(geometry, material);
   threeMesh.position.set(positions[0], positions[1], positions[2]);
-  
+
   // Create edges
   const edges = new THREE.EdgesGeometry(geometry);
   const lineMaterial = new THREE.LineBasicMaterial({ color: 0xffffff });
   const wireframe = new THREE.LineSegments(edges, lineMaterial);
-  
+
   // Add wireframe to mesh
   threeMesh.add(wireframe);
-  
+
   // Add to scene
   scene.add(threeMesh);
-  
+
   // Store reference
   objects.set(id, threeMesh);
 }
@@ -91,31 +104,31 @@ export function createObject(id, objData, scene) {
 // Update an existing 3D object
 export function updateObject(id, objData) {
   const object = objects.get(id);
-  
+
   // Update position
   object.position.set(
     objData.positions[0],
     objData.positions[1],
-    objData.positions[2]
+    objData.positions[2],
   );
 }
 
 // Reset world function
 export async function resetSimulation() {
   try {
-    await fetch('http://localhost:8080/worlds/threeBody/reset', {
-      method: 'POST'
+    await fetch("http://localhost:8080/worlds/threeBody/reset", {
+      method: "POST",
     });
   } catch (error) {
-    console.error('Error sending reset command:', error);
+    console.error("Error sending reset command:", error);
   }
 }
 
 // Setup keyboard event listeners
 export function setupKeyControls() {
-  window.addEventListener('keydown', (event) => {
-    if (event.key.toLowerCase() === 'r') {
-      console.log('Resetting simulation...');
+  window.addEventListener("keydown", (event) => {
+    if (event.key.toLowerCase() === "r") {
+      console.log("Resetting simulation...");
       resetSimulation();
     }
   });


### PR DESCRIPTION
## Summary
- add color field to `Object` and pass it through `World.Flatten`
- expose color array in API responses
- create example object with a color
- use color from backend when creating Three.js objects
- **change earth color to dark grey and return time first**

## Testing
- `go vet ./...` *(fails: directory prefix does not contain main module)*