### PR TITLE
Implement camera target cycling

### DIFF
--- a/front/src/camera.js
+++ b/front/src/camera.js
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { globals } from './global.js';
 
 // Initialize scene
 function createScene() {
@@ -80,3 +81,41 @@ export const renderer = createRenderer();
 export const controls = createControls(camera, renderer);
 
 setupResizeHandler(camera, renderer);
+
+export function FindClosestID(map) {
+  let closest = null;
+  let minDist = Infinity;
+  for (const [id, obj] of map.entries()) {
+    const dist = obj.position.length();
+    if (dist < minDist) {
+      minDist = dist;
+      closest = id;
+    }
+  }
+  return closest;
+}
+
+function teleportToObject(obj) {
+  if (!obj) {
+    return;
+  }
+  const geom = obj.geometry;
+  if (!geom.boundingSphere) {
+    geom.computeBoundingSphere();
+  }
+  const radius = geom.boundingSphere.radius;
+  const offset = new THREE.Vector3(radius * 3, radius * 3, radius * 3);
+  camera.position.copy(obj.position).add(offset);
+  controls.target.copy(obj.position);
+  controls.update();
+}
+
+export function LockOnID(map, id) {
+  const obj = map.get(id);
+  if (!obj) {
+    return;
+  }
+  globals.LockedID = id;
+  teleportToObject(obj);
+}
+

--- a/front/src/control.js
+++ b/front/src/control.js
@@ -1,5 +1,7 @@
 import { globals } from './global.js';
 import { reset } from './playback.js';
+import { objects } from './update.js';
+import { LockOnID } from "./camera.js";
 
 const speedDiv = document.getElementById('play-speed');
 
@@ -11,6 +13,10 @@ window.addEventListener('keydown', (event) => {
     if (globals.speed < 1) {
       globals.speed = 1;
     }
+  } else if (event.key === 'a') {
+    cycleTarget(-1);
+  } else if (event.key === 'd') {
+    cycleTarget(1);
   } else if (event.key === 'r') {
     reset();
   }
@@ -31,6 +37,19 @@ function initWorldList() {
 }
 
 initWorldList();
+
+function cycleTarget(delta) {
+  const IDs = Array.from(objects.keys());
+  if (IDs.length === 0) {
+    return;
+  }
+  let Index = IDs.indexOf(globals.LockedID);
+  if (Index === -1) {
+    Index = 0;
+  }
+  Index = (Index + delta + IDs.length) % IDs.length;
+  LockOnID(IDs[Index]);
+}
 
 
 document.querySelectorAll('.world-button').forEach(item => {

--- a/front/src/global.js
+++ b/front/src/global.js
@@ -3,7 +3,8 @@ export const globals = {
     frame: 0,
     chunk: 0,
     speed: 1,
-    maxFrame: 0
+    maxFrame: 0,
+    LockedID: null
 };
 
 export const cache = {

--- a/front/src/update.js
+++ b/front/src/update.js
@@ -1,12 +1,9 @@
 import * as THREE from "three";
-import { scene } from './camera.js';
+import { scene, controls, FindClosestID, LockOnID } from './camera.js';
+import { globals } from './global.js';
 
 // Object storage
 export const objects = new Map();
-
-
-
-
 // Update simulation objects based on data
 export function updateSimulation(data) {
   const {
@@ -45,6 +42,17 @@ export function updateSimulation(data) {
       scene.remove(objects.get(id));
       objects.delete(id);
     }
+  }
+
+  if (!globals.LockedID) {
+    const Closest = FindClosestID();
+    if (Closest) {
+      LockOnID(Closest);
+    }
+  }
+
+  if (globals.LockedID && objects.has(globals.LockedID)) {
+    controls.target.copy(objects.get(globals.LockedID).position);
   }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -15,4 +15,6 @@ multi simulation frontend
 
 
 TO DO:
-viewer: camera control. lock on objects. get their position, radius, and set to look at them. 
+viewer: camera control. lock on objects. get their position, radius, and set to look at them.
+new: use **A** and **D** keys to cycle locked targets. the camera snaps to the nearest object at start and moves to a good viewing distance.
+


### PR DESCRIPTION
## Summary
- move camera lock logic from update.js to camera.js
- update control.js to import the new helper
- keep controls target locked to moving objects
- adjust README to describe camera snapping behaviour

## Testing
- `npm test` *(fails: Error: no test specified)*
- `go vet ./...` *(fails: directory prefix does not contain main module)*