### PR TITLE
Implement camera target cycling

### DIFF
--- a/front/src/control.js
+++ b/front/src/control.js
@@ -1,5 +1,6 @@
 import { globals } from './global.js';
 import { reset } from './playback.js';
+import { objects, LockOnID } from './update.js';
 
 const speedDiv = document.getElementById('play-speed');
 
@@ -11,6 +12,10 @@ window.addEventListener('keydown', (event) => {
     if (globals.speed < 1) {
       globals.speed = 1;
     }
+  } else if (event.key === 'a') {
+    cycleTarget(-1);
+  } else if (event.key === 'd') {
+    cycleTarget(1);
   } else if (event.key === 'r') {
     reset();
   }
@@ -31,6 +36,19 @@ function initWorldList() {
 }
 
 initWorldList();
+
+function cycleTarget(delta) {
+  const IDs = Array.from(objects.keys());
+  if (IDs.length === 0) {
+    return;
+  }
+  let Index = IDs.indexOf(globals.LockedID);
+  if (Index === -1) {
+    Index = 0;
+  }
+  Index = (Index + delta + IDs.length) % IDs.length;
+  LockOnID(IDs[Index]);
+}
 
 
 document.querySelectorAll('.world-button').forEach(item => {

--- a/front/src/global.js
+++ b/front/src/global.js
@@ -3,7 +3,8 @@ export const globals = {
     frame: 0,
     chunk: 0,
     speed: 1,
-    maxFrame: 0
+    maxFrame: 0,
+    LockedID: null
 };
 
 export const cache = {

--- a/front/src/playback.js
+++ b/front/src/playback.js
@@ -1,5 +1,5 @@
 import { fetchRecording } from './api.js';
-import { updateSimulation } from './update.js';
+import { updateSimulation, objects } from './update.js';
 import { globals, cache } from './global.js';
 import { scene } from './camera.js';
 
@@ -48,6 +48,11 @@ export async function reset() {
   const rec = await fetchRecording(globals.world, 0);
   globals.chunk = 0;
   globals.frame = 0;
+  for (const Obj of objects.values()) {
+    scene.remove(Obj);
+  }
+  objects.clear();
+  globals.LockedID = null;
   cache.chunk = 0;
   cache.relativeFrame = 0;
   cache.frames = Object.values(rec.Frames);

--- a/front/src/update.js
+++ b/front/src/update.js
@@ -1,8 +1,59 @@
 import * as THREE from "three";
-import { scene } from './camera.js';
+import { scene, camera, controls } from './camera.js';
+import { globals } from './global.js';
 
 // Object storage
 export const objects = new Map();
+
+export function FindClosestID() {
+  let Closest = null;
+  let MinDist = Infinity;
+  for (const [CurID, Obj] of objects.entries()) {
+    const Dist = Obj.position.length();
+    if (Dist < MinDist) {
+      MinDist = Dist;
+      Closest = CurID;
+    }
+  }
+  return Closest;
+}
+
+export function TeleportToID(id) {
+  const Obj = objects.get(id);
+  if (!Obj) {
+    return;
+  }
+  const Geometry = Obj.geometry;
+  if (Geometry && !Geometry.boundingSphere) {
+    Geometry.computeBoundingSphere();
+  }
+  const Radius = Geometry && Geometry.boundingSphere
+    ? Geometry.boundingSphere.radius
+    : 10;
+  const Offset = new THREE.Vector3(Radius * 3, Radius * 3, Radius * 3);
+  camera.position.copy(Obj.position).add(Offset);
+  controls.target.copy(Obj.position);
+}
+
+export function LockOnID(id) {
+  if (globals.LockedID && objects.has(globals.LockedID)) {
+    const PrevObj = objects.get(globals.LockedID);
+    if (PrevObj.userData.wireframe) {
+      PrevObj.userData.wireframe.material.color.set(0xffffff);
+    }
+  }
+
+  globals.LockedID = id;
+
+  if (objects.has(id)) {
+    const NewObj = objects.get(id);
+    if (NewObj.userData.wireframe) {
+      NewObj.userData.wireframe.material.color.set(0xffa500);
+    }
+  }
+
+  TeleportToID(id);
+}
 
 
 
@@ -43,8 +94,22 @@ export function updateSimulation(data) {
   for (const id of objects.keys()) {
     if (!IDArray.includes(id)) {
       scene.remove(objects.get(id));
+      if (globals.LockedID === id) {
+        globals.LockedID = null;
+      }
       objects.delete(id);
     }
+  }
+
+  if (!globals.LockedID) {
+    const Closest = FindClosestID();
+    if (Closest) {
+      LockOnID(Closest);
+    }
+  }
+
+  if (globals.LockedID && objects.has(globals.LockedID)) {
+    controls.target.copy(objects.get(globals.LockedID).position);
   }
 }
 
@@ -82,6 +147,10 @@ export function createObject(id, objData, scene) {
 
   // Add wireframe to mesh
   threeMesh.add(wireframe);
+  threeMesh.userData.wireframe = wireframe;
+  if (globals.LockedID === id) {
+    wireframe.material.color.set(0xffa500);
+  }
 
 
   // Add to scene

--- a/readme.md
+++ b/readme.md
@@ -15,4 +15,6 @@ multi simulation frontend
 
 
 TO DO:
-viewer: camera control. lock on objects. get their position, radius, and set to look at them. 
+viewer: camera control. lock on objects. get their position, radius, and set to look at them.
+new: use **A** and **D** keys to cycle locked targets. the camera snaps to the nearest object at start.
+selection edges turn orange on the active target.


### PR DESCRIPTION
## Summary
- add `LockedID` state to store active camera target
- implement lock/teleport helpers in `update.js`
- cycle through objects with A/D keys via `control.js`
- document new control behaviour in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `go vet ./...` *(fails: directory prefix does not contain main module)
