### PR TITLE
Fix object locking and highlight

### DIFF
--- a/front/src/camera.js
+++ b/front/src/camera.js
@@ -115,7 +115,16 @@ export function LockOnID(map, id) {
   if (!obj) {
     return;
   }
+  if (globals.LockedID && map.has(globals.LockedID)) {
+    const prev = map.get(globals.LockedID);
+    if (prev.userData.wireframe) {
+      prev.userData.wireframe.material.color.set(0xffffff);
+    }
+  }
   globals.LockedID = id;
+  if (obj.userData.wireframe) {
+    obj.userData.wireframe.material.color.set(0xffa500);
+  }
   teleportToObject(obj);
 }
 

--- a/front/src/control.js
+++ b/front/src/control.js
@@ -1,7 +1,7 @@
 import { globals } from './global.js';
 import { reset } from './playback.js';
-import { objects } from './update.js';
-import { LockOnID } from "./camera.js";
+import { objects, IDList } from './update.js';
+import { LockOnID } from './camera.js';
 
 const speedDiv = document.getElementById('play-speed');
 
@@ -39,7 +39,7 @@ function initWorldList() {
 initWorldList();
 
 function cycleTarget(delta) {
-  const IDs = Array.from(objects.keys());
+  const IDs = IDList;
   if (IDs.length === 0) {
     return;
   }
@@ -48,7 +48,7 @@ function cycleTarget(delta) {
     Index = 0;
   }
   Index = (Index + delta + IDs.length) % IDs.length;
-  LockOnID(IDs[Index]);
+  LockOnID(objects, IDs[Index]);
 }
 
 

--- a/front/src/update.js
+++ b/front/src/update.js
@@ -2,6 +2,8 @@ import * as THREE from "three";
 import { scene, controls, FindClosestID, LockOnID } from './camera.js';
 import { globals } from './global.js';
 
+export const IDList = [];
+
 // Object storage
 export const objects = new Map();
 // Update simulation objects based on data
@@ -31,6 +33,9 @@ export function updateSimulation(data) {
 
     if (!objects.has(id)) {
       createObject(id, objData, scene);
+      if (!IDList.includes(id)) {
+        IDList.push(id);
+      }
     } else {
       updateObject(id, objData);
     }
@@ -41,13 +46,17 @@ export function updateSimulation(data) {
     if (!IDArray.includes(id)) {
       scene.remove(objects.get(id));
       objects.delete(id);
+      const idx = IDList.indexOf(id);
+      if (idx !== -1) {
+        IDList.splice(idx, 1);
+      }
     }
   }
 
   if (!globals.LockedID) {
-    const Closest = FindClosestID();
+    const Closest = FindClosestID(objects);
     if (Closest) {
-      LockOnID(Closest);
+      LockOnID(objects, Closest);
     }
   }
 
@@ -90,6 +99,10 @@ export function createObject(id, objData, scene) {
 
   // Add wireframe to mesh
   threeMesh.add(wireframe);
+  threeMesh.userData.wireframe = wireframe;
+  if (globals.LockedID === id) {
+    wireframe.material.color.set(0xffa500);
+  }
 
 
   // Add to scene


### PR DESCRIPTION
## Summary
- maintain ordered `IDList` of objects
- use that list for cycling targets
- highlight locked object's edges orange
- fix calls to `LockOnID` and `FindClosestID`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run build` *(fails: vite not found)*